### PR TITLE
fix IPv6 issue (#4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haythem/public-ip",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Queries the runner's public IP address",
   "private": true,
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haythem/public-ip",
-  "version": "1.0.2",
+  "version": "1.2.0",
   "description": "Queries the runner's public IP address",
   "private": true,
   "main": "dist/index.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ export async function run(): Promise<void> {
 
   try {
     const ipv4 = await http.getJson<IPResponse>('https://api.ipify.org?format=json');
-    const ipv6 = await http.getJson<IPResponse>('https://api6.ipify.org?format=json');
+    const ipv6 = await http.getJson<IPResponse>('https://api64.ipify.org?format=json');
 
     core.setOutput('ipv4', ipv4.result.ip);
     core.setOutput('ipv6', ipv6.result.ip);


### PR DESCRIPTION
fixes https://github.com/TheGuarantors/tg-modern/pull/872

use Universal: IPv4/IPv6 endpoint

The IPv6 endpoint has been removed on October 1st by [ipfy](https://www.ipify.org/). Instead it now uses the `https://api64.ipify.org` endpoint, which return an IPv6 address if available or fallback to IPv4. The change is backward compatible since `README.md` already accounted for fallback to IPv4 `Public IPv6 of the runner. If not available the `ipv4` will be returned`
