### PR TITLE
Retry on error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Public IP
         id: ip
-        uses: haythem/public-ip@v1.3
+        uses: "./"
 
       - name: Restore Cache
         uses: actions/cache@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Public IP
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Public IP
+      id: ip
+      uses: rodrigoegimenez/public-ip@feat/retry-on-error
+
+    - name: Print Public IP
+      run: |
+        echo ${{ steps.ip.outputs.ipv4 }}
+        echo ${{ steps.ip.outputs.ipv6 }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Public IP
-      id: ip
-      uses: rodrigoegimenez/public-ip@feat/retry-on-error
+      - uses: actions/checkout@v1
 
-    - name: Print Public IP
-      run: |
-        echo ${{ steps.ip.outputs.ipv4 }}
-        echo ${{ steps.ip.outputs.ipv6 }}
+      - name: Public IP
+        id: ip
+        uses: "./"
+
+      - name: Print Public IP
+        run: |
+          echo ${{ steps.ip.outputs.ipv4 }}
+          echo ${{ steps.ip.outputs.ipv6 }}
+

--- a/dist/index.js
+++ b/dist/index.js
@@ -2741,16 +2741,26 @@ function run() {
             allowRetries: true,
             maxRetries: maxRetries
         });
-        try {
-            const ipv4 = yield http.getJson("https://api.ipify.org?format=json");
-            const ipv6 = yield http.getJson("https://api64.ipify.org?format=json");
-            core.setOutput("ipv4", ipv4.result.ip);
-            core.setOutput("ipv6", ipv6.result.ip);
-            core.info(`ipv4: ${ipv4.result.ip}`);
-            core.info(`ipv6: ${ipv6.result.ip}`);
-        }
-        catch (error) {
-            core.setFailed(error === null || error === void 0 ? void 0 : error.message);
+        let numTries = 0;
+        let success = false;
+        while (!success && numTries < maxRetries) {
+            try {
+                core.info(`Attempt: ${numTries + 1} of ${maxRetries}`);
+                const ipv4 = yield http.getJson("https://api.ipify.org?format=json");
+                const ipv6 = yield http.getJson("https://api64.ipify.org?format=json");
+                core.setOutput("ipv4", ipv4.result.ip);
+                core.setOutput("ipv6", ipv6.result.ip);
+                core.info(`ipv4: ${ipv4.result.ip}`);
+                core.info(`ipv6: ${ipv6.result.ip}`);
+                success = true;
+            }
+            catch (error) {
+                core.debug(`Error: ${error === null || error === void 0 ? void 0 : error.message}.`);
+                if (numTries == maxRetries - 1) {
+                    core.setFailed(error === null || error === void 0 ? void 0 : error.message);
+                }
+            }
+            numTries++;
         }
     });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,8 +13,8 @@ export async function run(): Promise<void> {
     maxRetries: maxRetries
   });
 
-  var numTries = 0;
-  var success = false;
+  let numTries = 0;
+  let success = false;
   while (!success && numTries < maxRetries) {
     console.log(success);
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,21 +13,31 @@ export async function run(): Promise<void> {
     maxRetries: maxRetries
   });
 
-  try {
-    const ipv4 = await http.getJson<IPResponse>(
-      "https://api.ipify.org?format=json"
-    );
-    const ipv6 = await http.getJson<IPResponse>(
-      "https://api64.ipify.org?format=json"
-    );
+  var numTries = 0;
+  var success = false;
+  while (!success && numTries < maxRetries) {
+    console.log(success);
+    try {
+      const ipv4 = await http.getJson<IPResponse>(
+        "https://api.ipify.org?format=json"
+      );
+      const ipv6 = await http.getJson<IPResponse>(
+        "https://api64.ipify.org?format=json"
+      );
 
-    core.setOutput("ipv4", ipv4.result.ip);
-    core.setOutput("ipv6", ipv6.result.ip);
+      core.setOutput("ipv4", ipv4.result.ip);
+      core.setOutput("ipv6", ipv6.result.ip);
 
-    core.info(`ipv4: ${ipv4.result.ip}`);
-    core.info(`ipv6: ${ipv6.result.ip}`);
-  } catch (error) {
-    core.setFailed(error?.message);
+      core.info(`ipv4: ${ipv4.result.ip}`);
+      core.info(`ipv6: ${ipv6.result.ip}`);
+      success = true;
+      console.log("success");
+    } catch (error) {
+      if (numTries == maxRetries - 1) {
+        core.setFailed(error?.message);
+      }
+    } 
+    numTries++;
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,8 +16,8 @@ export async function run(): Promise<void> {
   let numTries = 0;
   let success = false;
   while (!success && numTries < maxRetries) {
-    console.log(success);
     try {
+      core.info(`Attempt: ${numTries + 1} of ${maxRetries}`);
       const ipv4 = await http.getJson<IPResponse>(
         "https://api.ipify.org?format=json"
       );
@@ -31,12 +31,12 @@ export async function run(): Promise<void> {
       core.info(`ipv4: ${ipv4.result.ip}`);
       core.info(`ipv6: ${ipv6.result.ip}`);
       success = true;
-      console.log("success");
     } catch (error) {
+      core.debug(`Error: ${error?.message}.`);
       if (numTries == maxRetries - 1) {
         core.setFailed(error?.message);
       }
-    } 
+    }
     numTries++;
   }
 }


### PR DESCRIPTION
This adds an extra retry layer independent of @actions/http-client's, this handles ECONNRESET and ETIMEDOUT errors and should fix #23 .